### PR TITLE
Hotfix Use Ninja generator in CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "configurePresets": [
     {
       "name": "debug",
+      "generator": "Ninja",
       "binaryDir": "build/debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -12,6 +13,7 @@
     },
     {
       "name": "release",
+      "generator": "Ninja",
       "binaryDir": "build/release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",


### PR DESCRIPTION
Add "generator": "Ninja" to the debug and release configure presets in CMakePresets.json so CMake will use the Ninja build system for both build types, ensuring consistent and faster builds.